### PR TITLE
Feature/outline menu items

### DIFF
--- a/src/components/Dashboard/TheSidebar.vue
+++ b/src/components/Dashboard/TheSidebar.vue
@@ -1,58 +1,47 @@
 <template>
   <b-menu>
-    <b-menu-list>
+    <b-menu-list
+      v-for="menuListItem in groupMenuList"
+      :key="menuListItem.group"
+      :label="menuListItem.label"
+    >
       <b-menu-item
-        :to="{ name: 'backoffice.dashboard' }"
+        v-for="menuItem in menuListItem.menu_items"
+        :key="menuItem.to.name"
+        :to="menuItem.to"
         tag="router-link"
-        icon="chart-line"
-        label="View Dashboard"
-      ></b-menu-item>
-    </b-menu-list>
-
-    <b-menu-list label="Triage">
-      <b-menu-item
-        :to="{ name: 'backoffice.triageNew' }"
-        tag="router-link"
-        icon="plus"
-        label="Admit a patient"
-      ></b-menu-item>
-    </b-menu-list>
-
-    <b-menu-list label="Admitted Patients">
-      <b-menu-item
-        :to="{ name: 'backoffice.admissionsList' }"
-        tag="router-link"
-        icon="bed"
-        label="Admitted patients"
-      ></b-menu-item>
-    </b-menu-list>
-
-    <b-menu-list label="Bed Management">
-      <b-menu-item
-        :to="{ name: 'backoffice.bedTypeList' }"
-        tag="router-link"
-        icon="bed"
-        label="See all bed types"
-      ></b-menu-item>
-      <b-menu-item
-        :to="{ name: 'backoffice.bedList' }"
-        tag="router-link"
-        icon="bed"
-        label="See all beds"
-      ></b-menu-item>
-    </b-menu-list>
-
-    <b-menu-list label="Health Snapshots">
-      <b-menu-item
-        :to="{ name: 'backoffice.healthSnapshotNew' }"
-        tag="router-link"
-        icon="plus"
-        label="Create a health snapshot"
+        :icon="menuItem.icon"
+        :label="menuItem.label"
       ></b-menu-item>
     </b-menu-list>
   </b-menu>
 </template>
 
 <script>
-export default {};
+import { mapState } from "vuex";
+export default {
+  computed: {
+    ...mapState(["sidebarmenu", "user", "patient", "admission"]),
+    groupMenuList: function() {
+      // Filter the sidebarMenuList for the user's groups
+
+      var list = this.sidebarmenu.sidebarMenuList.filter(
+        listitem => this.user.groups.indexOf(listitem.group) >= 0
+      );
+
+      // For the remaining groups, filter the menu items to show
+      // only those without a context, or where the current state
+      // has an item for the context.
+      // For example, if the context of an item is an admission, and
+      // and the store state has an admission set, keep the item.
+      list.forEach(listitem => {
+        listitem.menu_items = listitem.menu_items.filter(
+          item => !item.context || (this[item.context] && this[item.context].id)
+        );
+      });
+
+      return list;
+    }
+  }
+};
 </script>

--- a/src/store/admission.js
+++ b/src/store/admission.js
@@ -1,0 +1,5 @@
+const state = {};
+export default {
+  state,
+  namespaced: true,
+};

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -7,7 +7,11 @@ import admissions from "./admissions";
 import triage from "./triage";
 import beds from "./beds";
 import healthsnapshots from "./healthsnapshots";
+import sidebarmenu from "./sidebarmenu";
+import user from "./user";
 import auth from "./auth";
+import patient from "./patient";
+import admission from "./admission";
 
 Vue.use(Vuex);
 
@@ -18,6 +22,10 @@ export default new Vuex.Store({
     triage,
     beds,
     auth,
-    healthsnapshots
-  }
+    healthsnapshots,
+    sidebarmenu,
+    patient,
+    admission,
+    user,
+  },
 });

--- a/src/store/patient.js
+++ b/src/store/patient.js
@@ -1,0 +1,5 @@
+const state = {};
+export default {
+  state,
+  namespaced: true,
+};

--- a/src/store/sidebarmenu.js
+++ b/src/store/sidebarmenu.js
@@ -1,0 +1,208 @@
+const state = {
+  sidebarMenuList: [
+    {
+      label: "Triage",
+      group: "triage",
+      menu_items: [
+        {
+          to: { name: "backoffice.triageNew" },
+
+          icon: "plus",
+          label: "Admit a patient",
+        },
+        {
+          to: { name: "backoffice.triageList" },
+
+          icon: "bed",
+          label: "Recently triaged",
+        },
+      ],
+    },
+
+    {
+      label: "Patient Admin",
+      group: "patients",
+      menu_items: [
+        {
+          to: { name: "backoffice.patientSearch" },
+
+          icon: "magnify",
+          label: "Search patient",
+        },
+        {
+          to: { name: "backoffice.admitNew" },
+          context: "patient",
+          icon: "plus",
+          label: "Admit a patient",
+        },
+        {
+          to: { name: "backoffice.admissionsList" },
+
+          icon: "bed",
+          label: "Recent admissions",
+        },
+        {
+          to: { name: "backoffice.patientDetails" },
+          context: "patient",
+          icon: "card-account-details",
+          label: "View / edit patient details",
+        },
+        {
+          to: { name: "backoffice.admissionMoveToPatient" },
+          context: "admission",
+          icon: "folder-move",
+          label: "Move admission to existing patient",
+        },
+      ],
+    },
+
+    {
+      label: "Bedside Care",
+      group: "bedside",
+      menu_items: [
+        {
+          to: { name: "backoffice.bedsideSearch" },
+
+          icon: "magnify",
+          label: "Search patient",
+        },
+      ],
+    },
+
+    {
+      label: "Specialist Care",
+      group: "specialist",
+      menu_items: [
+        {
+          to: { name: "backoffice.patientSpecialistSearch" },
+
+          icon: "magnify",
+          label: "Search patient",
+        },
+      ],
+    },
+
+    {
+      label: "Pharmacy",
+      group: "pharmacy",
+      menu_items: [
+        {
+          to: { name: "backoffice.prescriptionsList" },
+
+          icon: "script-text",
+          label: "Recent prescriptions",
+        },
+        {
+          to: { name: "backoffice.prescriptionsSearch" },
+
+          icon: "magnify",
+          label: "Search prescription",
+        },
+      ],
+    },
+
+    {
+      label: "Laboratory",
+      group: "laboratory",
+      menu_items: [
+        {
+          to: { name: "backoffice.labRequestsList" },
+
+          icon: "tray-full",
+          label: "Recent requests",
+        },
+        {
+          to: { name: "backoffice.labRequestsSearch" },
+
+          icon: "magnify",
+          label: "Search requests",
+        },
+      ],
+    },
+
+    {
+      label: "Ward support",
+      group: "ward-support",
+      menu_items: [
+        {
+          to: { name: "backoffice.patientMoveList" },
+
+          icon: "vector-polyline",
+          label: "Move patient",
+        },
+        {
+          to: { name: "backoffice.cleaningList" },
+
+          icon: "bed-empty",
+          label: "Cleaning required",
+        },
+        {
+          to: { name: "backoffice.equipmentDeliveryList" },
+
+          icon: "washing-machine",
+          label: "Deliver equipment",
+        },
+        {
+          to: { name: "backoffice.mealsRequestList" },
+
+          icon: "silverware-fork-knife",
+          label: "Meals required",
+        },
+      ],
+    },
+    {
+      label: "Dashboard",
+      group: "mgt-dashboard",
+      menu_items: [
+        {
+          to: { name: "backoffice.dashboard" },
+
+          icon: "chart-line",
+          label: "View Dashboard",
+        },
+      ],
+    },
+
+    {
+      label: "Manage",
+      group: "manage",
+      menu_items: [
+        {
+          to: { name: "backoffice.bedTypeList" },
+
+          icon: "bed-empty",
+          label: "Manage bed types",
+        },
+        {
+          to: { name: "backoffice.bedList" },
+
+          icon: "bed-empty",
+          label: "See all beds",
+        },
+        {
+          to: { name: "backoffice.equipmentTypeList" },
+
+          icon: "washing-machine",
+          label: "Manage equipment types",
+        },
+        {
+          to: { name: "backoffice.equipmentList" },
+
+          icon: "washing-machine",
+          label: "See all equipment",
+        },
+        {
+          to: { name: "backoffice.userManage" },
+
+          icon: "account-multiple-outline",
+          label: "Manage users",
+        },
+      ],
+    },
+  ],
+};
+
+export default {
+  state,
+  namespaced: true,
+};

--- a/src/store/sidebarmenu.js
+++ b/src/store/sidebarmenu.js
@@ -30,15 +30,25 @@ const state = {
           label: "Search patient",
         },
         {
+          to: { name: "backoffice.registerPatient" },
+          icon: "plus",
+          label: "Register a patient",
+        },
+        {
           to: { name: "backoffice.admitNew" },
           context: "patient",
-          icon: "plus",
+          icon: "import",
           label: "Admit a patient",
         },
         {
-          to: { name: "backoffice.admissionsList" },
+          to: { name: "backoffice.patientsList" },
 
-          icon: "bed",
+          icon: "account-group",
+          label: "Recent patient registrations",
+        },
+        {
+          to: { name: "backoffice.admissionsList" },
+          icon: "clipboard-list",
           label: "Recent admissions",
         },
         {

--- a/src/store/user.js
+++ b/src/store/user.js
@@ -1,0 +1,18 @@
+const state = {
+  groups: [
+    "triage",
+    "bedside",
+    "patients",
+    "specialist",
+    "pharmacy",
+    "laboratory",
+    "ward-support",
+    "mgt-dashboard",
+    "manage",
+  ],
+};
+
+export default {
+  state,
+  namespaced: true,
+};


### PR DESCRIPTION
The aim is to create a fairly complete sidebar of actions we might implement. 

Make the sidebar configurable, allowing it to be filtered based on a user's groups (do they perform triage and bedside care for example). Also, allow individual items to be displayed based on context. For example, is a current admission being viewed.

Two blank store components have been added, for admission and patient, in order to test this. A user has also been added, defaulting to all groups. This should be backed by an API eventually.

The sidebar configuration has been pushed into the store too, since it might allow us to drive this from an API eventually (allowing more backend configuration of the frontend), but this isn't really necessary.