### PR TITLE
Add an Admission view

### DIFF
--- a/src/components/Admissions/HealthSnapshotsList.vue
+++ b/src/components/Admissions/HealthSnapshotsList.vue
@@ -1,0 +1,109 @@
+<template>
+  <div>
+    <div class="list-actions">
+      <router-link
+        :to="{name: 'backoffice.admission', params: { admission_id: admission_id }}"
+        class="card-footer-item"
+      >Add Health Snapshot</router-link>
+    </div>
+    <section class="section">
+      <b-table
+        :data="healthSnapshots"
+        :default-sort="['created_at', 'desc']"
+        hoverable
+        paginated
+        :loading="!healthSnapshots "
+      >
+        <template slot-scope="props">
+          <b-table-column field="created_at" label="Date/Time" sortable>
+            {{
+            props.row.created_at | datetime
+            }}
+          </b-table-column>
+
+          <b-table-column field="severity" label="Severity" sortable>
+            {{
+            props.row.severity
+            }}
+          </b-table-column>
+
+          <b-table-column field="heart_rate" label="HR" sortable>
+            {{
+            props.row.heart_rate
+            }}
+          </b-table-column>
+
+          <b-table-column field="breathing_rate" label="BR" sortable>{{ props.row.breathing_rate }}</b-table-column>
+
+          <b-table-column
+            field="blood_pressure_systolic"
+            label="BPS"
+            sortable
+          >{{ props.row.blood_pressure_systolic }}</b-table-column>
+
+          <b-table-column
+            field="blood_pressure_diastolic"
+            label="BPD"
+            sortable
+          >{{ props.row.blood_pressure_diastolic }}</b-table-column>
+
+          <b-table-column label="GCS">
+            {{
+            props.row.gcs_eye + props.row.gcs_motor + props.row.gcs_verbal
+            }}
+          </b-table-column>
+        </template>
+        <template slot="empty">
+          <section class="section">
+            <div class="content has-text-grey has-text-centered">
+              <p>
+                <b-icon icon="emoticon-sad" size="is-large"></b-icon>
+              </p>
+              <p>Nothing here.</p>
+            </div>
+          </section>
+        </template>
+      </b-table>
+    </section>
+  </div>
+</template>
+
+<script>
+import { mapActions, mapState } from "vuex";
+
+export default {
+  props: {
+    admission_id: { type: String, required: false }
+  },
+  watch: {
+    $route: "reloadHealthSnapshots"
+  },
+
+  computed: {
+    ...mapState("healthsnapshots", ["healthSnapshots"], "admissions", [
+      "admission"
+    ])
+  },
+  mounted() {
+    this.reloadHealthSnapshots();
+  },
+  methods: {
+    ...mapActions("healthsnapshots", ["fetchHealthSnapshots"]),
+    reloadHealthSnapshots() {
+      let hs = this.$store.state.healthSnapshots;
+
+      if (
+        this.admission_id &&
+        (!hs || !hs[0] || hs[0].admission_id != this.admission_id)
+      ) {
+        this.$store.dispatch(
+          "patients/fetchHealthSnapshots",
+          this.admission_id
+        );
+      }
+    }
+  }
+};
+</script>
+
+<style></style>

--- a/src/router/backoffice.js
+++ b/src/router/backoffice.js
@@ -55,6 +55,7 @@ const routes = {
     {
       path: "admissions/:admission_id",
       name: "backoffice.admission",
+      props: true,
       component: () =>
         import(
           /* webpackChunkName: "backoffice" */ "../views/backoffice/admissions/Admission.vue"

--- a/src/store/admissions.js
+++ b/src/store/admissions.js
@@ -4,9 +4,11 @@ const ADMISSION_ENDPOINT = "admission";
 
 const MUTATIONS = {
   SET_ADMISSIONS: "ADMISSIONS",
+  SET_ADMISSION: "ADMISSION",
 };
 
 const state = {
+  admission: {},
   admissions: [],
 };
 
@@ -15,6 +17,9 @@ const getters = {};
 const mutations = {
   [MUTATIONS.SET_ADMISSIONS](state, admissions) {
     state.admissions = admissions;
+  },
+  [MUTATIONS.SET_ADMISSION](state, admission) {
+    state.admission = admission;
   },
 };
 
@@ -27,6 +32,18 @@ const actions = {
         params: data,
       });
       commit(MUTATIONS.SET_ADMISSIONS, response.data);
+    } catch (e) {
+      console.log(e);
+    }
+  },
+  async fetchAdmission({ commit }, id) {
+    try {
+      commit(MUTATIONS.SET_ADMISSION, {});
+      const response = await API.service.get(
+        ADMISSION_ENDPOINT + "/" + id + "/"
+      );
+      const admission = { ...response.data };
+      commit(MUTATIONS.SET_ADMISSION, admission);
     } catch (e) {
       console.log(e);
     }

--- a/src/views/backoffice/admissions/Admission.vue
+++ b/src/views/backoffice/admissions/Admission.vue
@@ -2,21 +2,141 @@
   <div>
     <section class="section">
       <h1 class="title is-2">Admission</h1>
+      <div class="card" v-if="admission && admission.id">
+        <div class="card-header">
+          <div class="card-content">
+            <div class="media">
+              <div class="media-left">
+                <figure class="image is-96x96">
+                  <img src="https://bulma.io/images/placeholders/96x96.png" alt="Patient photo" />
+                </figure>
+              </div>
+              <div class="media-content">
+                <p class="title is-4">{{ admission.patient_display || '-' }}</p>
+                <p class>
+                  <span>Admitted at:</span>
+                  {{ admission.admitted_at | datetime }}
+                </p>
+                <p class>
+                  <span>Bed:</span>
+                  {{ admission.current_bed }}
+                </p>
+                <p class>
+                  <span>Status:</span>
+                  {{ admission.current_severity }}
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div v-if="admission.admitted" class="card-header">
+          <router-link
+            :to="{name: 'backoffice.admission', params: { admission_id: admission_id }}"
+            class="card-footer-item"
+          >Change Bed</router-link>
+          <router-link
+            :to="{name: 'backoffice.admission', params: { admission_id: admission_id }}"
+            class="card-footer-item"
+          >Discharge</router-link>
+          <router-link
+            :to="{name: 'backoffice.admission', params: { admission_id: admission_id }}"
+            class="card-footer-item"
+          >Transfer</router-link>
+          <router-link
+            :to="{name: 'backoffice.admission', params: { admission_id: admission_id }}"
+            class="card-footer-item"
+          >Deceased</router-link>
+        </div>
+        <div v-else class="card-header">
+          <span class="card-footer-item">Previous Admission</span>
+        </div>
+        <div class="extra-content">
+          <div class="card-content">
+            <b-collapse aria-id="healthSnapshots" class="card" animation="slide" :open="false">
+              <div
+                slot="trigger"
+                slot-scope="props"
+                class="card-header"
+                role="button"
+                aria-controls="healthSnapshots"
+                animation="slide"
+              >
+                <p class="card-header-title">
+                  Health Snapshots
+                  <b-icon :icon="props.open ? 'menu-down' : 'menu-up'"></b-icon>
+                </p>
+              </div>
+              <div class="card-content">
+                <div class="content">
+                  <health-snapshots-list :admission="admission" />
+                </div>
+              </div>
+            </b-collapse>
+            <b-collapse aria-id="admissionHealth" class="card" animation="slide" :open="false">
+              <div
+                slot="trigger"
+                slot-scope="props"
+                class="card-header"
+                role="button"
+                aria-controls="admissionHealth"
+                animation="slide"
+              >
+                <p class="card-header-title">
+                  Admission Conditions
+                  <b-icon :icon="props.open ? 'menu-down' : 'menu-up'"></b-icon>
+                </p>
+              </div>
+              <div class="card-content">
+                <div class="content">
+                  <p>Overall Wellbeing</p>
+                  <p>Common Symptons</p>
+                  <p>Graded Symptons</p>
+                  <p>Related Conditions</p>
+                  <p>Admission Health Snapshot</p>
+                </div>
+              </div>
+            </b-collapse>
+          </div>
+        </div>
+      </div>
     </section>
   </div>
 </template>
 
 <script>
-// import { mapActions, mapState } from "vuex";
+import { mapActions, mapState } from "vuex";
+import HealthSnapshotsList from "@/components/Admissions/HealthSnapshotsList.vue";
 
 export default {
+  components: {
+    HealthSnapshotsList
+  },
   props: {
     admission_id: { type: String, required: false }
   },
+  watch: {
+    $route: "reloadAdmission"
+  },
+  computed: {
+    ...mapState("admissions", ["admission"])
+  },
 
-  computed: {},
-  mounted() {},
-  methods: {}
+  mounted() {
+    this.reloadAdmission();
+  },
+  methods: {
+    ...mapActions("admissions", ["fetchAdmission"]),
+
+    reloadAdmission() {
+      let admission = this.$store.state.admission;
+      if (
+        this.admission_id &&
+        (!admission || admission.id != this.admission_id)
+      ) {
+        this.$store.dispatch("admissions/fetchAdmission", this.admission_id);
+      }
+    }
+  }
 };
 </script>
 

--- a/src/views/backoffice/admissions/Admission.vue
+++ b/src/views/backoffice/admissions/Admission.vue
@@ -13,6 +13,7 @@
               </div>
               <div class="media-content">
                 <p class="title is-4">{{ admission.patient_display || '-' }}</p>
+                <p class>{{ admission.local_barcode }}</p>
                 <p class>
                   <span>Admitted at:</span>
                   {{ admission.admitted_at | datetime }}

--- a/src/views/backoffice/admissions/AdmissionsList.vue
+++ b/src/views/backoffice/admissions/AdmissionsList.vue
@@ -72,8 +72,9 @@ export default {
     ...mapActions("admissions", ["fetchAdmissions"]),
 
     open_row(row) {
+      this.$store.dispatch("user/setCurrentView", { admission: row });
       this.$router.push({
-        name: "backoffice.healthSnapshotForAdmission",
+        name: "backoffice.admission",
         params: { admission: row, admission_id: row.id }
       });
     }

--- a/src/views/backoffice/index.vue
+++ b/src/views/backoffice/index.vue
@@ -44,8 +44,8 @@ export default {
     if (!this.tokens.access && this.$route.name !== "generic.login") {
       await this.$router.push({ name: "generic.login" });
     } else {
-      await this.fetchSubmissions();
-      await this.fetchAdmissions();
+      // await this.fetchSubmissions();
+      // await this.fetchAdmissions();
     }
   },
   watch: {


### PR DESCRIPTION
Create a view for an admission. Provides an entry point into viewing 

- health snapshots
- the initial triage submissions
- actions related to the patient (discharge, deceased...)
- eventually prescriptions, etc.
